### PR TITLE
#Refactor AWS CLI into a bash script

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,41 @@ gp env HELLO='world'
 All future workspaces launched will set the env vars for all bash terminals opened in thoes workspaces.
 
 You can also set en vars in the `.gitpod.yml` but this can only contain non-senstive env vars.
+
+
+#### PROJECT_ROOT removed from install-terraform-cli
+
+ The env variable along with command was mistakenly kept in install-terraform-cli file and it is removed.
+ Removed content:
+ 
+ PROJECT_ROOT='/workspace/terraform-beginner-bootcamp-2023'
+
+
+ #### AWS CLI Istallation
+
+ AWS CLI is installed for the project via the bash script `./bin/install_aws_cli`
+ 
+ [Getting Started Install (AWS CLI) ](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+
+[AWS CLI Env Vars](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html)
+
+We can check if our AWS credentials is configured correctly by running the following AWS CLI command:
+
+```sh
+aws sts get-caller-identity
+```
+ 
+ If it is succesful you should see a json payload return that looks like this:
+
+```json
+ {
+    "UserId": "AIEAVUO15ZPAAJ5WIJ5KR",
+    "Account": "123456789012",
+    "Arn": "arn:aws:iam::123456789012:user/terraform-beginner-bootcamp"
+}
+```
+
+We'll need to generate AWS CLI credits from IAM User in order to the user AWS CLI.
+
+- Logged in to AWS console and created **iamadmin** user form IAM Console
+- The **iamadmin** user is currently given **Admin Acess**

--- a/bin/install-terraform-cli.sh
+++ b/bin/install-terraform-cli.sh
@@ -1,6 +1,4 @@
 #!/usr/bi/env bash
-
-PROJECT_ROOT '/workspace/terraform-beginner-bootcamp-2023'
 cd /workspace
 sudo apt-get update && sudo apt-get install -y gnupg software-properties-common curl
 wget -O- https://apt.releases.hashicorp.com/gpg | \


### PR DESCRIPTION
- Refactor AWS CLI into bash Script.
- Provide env var examples for AWS CLI requirements
- set our env vars for AWS using gp env
- Content was not saved in install_aws_cli and had to rewrite and commit 